### PR TITLE
Book Information Source Preference per Jeff

### DIFF
--- a/src/content/docs/librarians/Editing.mdx
+++ b/src/content/docs/librarians/Editing.mdx
@@ -11,7 +11,7 @@ layout: ../../../layouts/librarians.astro
 In order of preference:
 1. Publisher
 2. Author Official Website
-3. BookBub/ WorldCat
+3. BookBub / WorldCat
 4. Bookstore (Barnes & Noble, Amazon, etc)
 5. Other Book Site (Open Library, Google Books, etc)
 

--- a/src/content/docs/librarians/Editing.mdx
+++ b/src/content/docs/librarians/Editing.mdx
@@ -7,6 +7,14 @@ layout: ../../../layouts/librarians.astro
 ---
 
 ## General
+### What is the authoratative source for book descriptions / other information?
+In order of preference:
+1. Publisher
+2. Author Official Website
+3. BookBub/ WorldCat
+4. Bookstore (Barnes & Noble, Amazon, etc)
+5. Other Book Site (Open Library, Google Books, etc)
+
 ### My update didn’t work? What’s going on?
 This is a bug Adam’s currently working on getting to the bottom of. If you run into this, you can either skip that book for now, or start a thread in the librarian channel with as much information as possible to help reproduce the error (link to the page you were editing, what fields you changed).
 


### PR DESCRIPTION
# Description
Added list of Book information source preference from Jeff on discord

# Hardcover or Discord Username
@syn

# Types of changes
- [x] New content
- [ ] Updated content
- [ ] Deleted content
- [ ] Broken link
- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.

# How to test it?
N/A