### PR TITLE
Update SeriesStandards.mdx; Add adaptations

### DIFF
--- a/src/content/docs/librarians/Standards/SeriesStandards.mdx
+++ b/src/content/docs/librarians/Standards/SeriesStandards.mdx
@@ -2,7 +2,7 @@
 title: Series Standards
 description: Standards for adding and editing series in Hardcover.
 category: guide
-lastUpdated: 2025-01-07 08:00:00
+lastUpdated: 2025-02-08 09:57:47
 layout: ../../../../layouts/librarians.astro
 ---
 
@@ -10,6 +10,12 @@ layout: ../../../../layouts/librarians.astro
 For multiple series with the same name, adjust the additional series as follows:
   - Append `(Author Name)` to the series name 
   - Append `-AuthorName` to the slug
+
+When a series has been adapted into a different format (e.g., a manga that was novelized), we create a separate series for the adaptation:
+  - The source format retains the series name (e.g., `The Summer Hikaru Died`)
+  - For the adaptation, append `(Format)` to the series name (e.g., `The Summer Hikaru Died (Light Novel)`
+  - For the adaptation, append `-format` to the slug (e.g., `the-summer-hikaru-died-lightnovel`)
+
 
 ## Publisher Collections (E.g., Penguin Little Black Classics)
 For publisher or other collections where only a specific edition of a book is part of the series, a Hardcover series should not be created. The book may be instead added to a list.


### PR DESCRIPTION
# Description
As per our discussion yesterday this adds clarification for a series that has been adapted to a different (reading) format.
I'm not 100% sold on my wording here, though - the _format_ terminology on Hardcover refers to Physical/Ebook/Audio. Maybe there's a better term I could use here?


# Hardcover or Discord Username
Discord snickers_anyone

# Types of changes
- [ ] New content
- [x] Updated content
- [ ] Deleted content
- [ ] Broken link
- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.
