### PR TITLE
chore: mention `user-agent` header in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Use our amazing stats and tools, including AI, to discover new horizons in your 
     ```
 2. **Navigate to the project directory:**
    ```bash
-   cd hardcover-doc
+   cd hardcover-docs
    ```
 3. **Install dependencies:**
     ```bash

--- a/src/content/docs/api/Getting-Started.mdx
+++ b/src/content/docs/api/Getting-Started.mdx
@@ -71,6 +71,7 @@ The API will return the following response codes:
 | 500  | Internal Server Error                                        | `{ error: "An unknown error occurred" }`    |
 
 ## Important Notes About the Hardcover API
+- When making requests from your own script, include a `User-Agent` header in your request.
 - The API is still heavily in flux right now. Anything you build using it could break in the future.
 - We may reset tokens without notice while in beta.
 - The same ownership rights exist for this as anything on the site.


### PR DESCRIPTION
# Description

It seems the `User-Agent` header is now required, without it the API will return a 403 forbidden.

Also fixed a typo in README.

# Hardcover or Discord Username

Hardcover username: @ruru

# Types of changes
- [ ] New content
- [x] Updated content
- [ ] Deleted content
- [ ] Broken link
- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.
