### PR TITLE
 IT Translation - Contributing Guides

### DIFF
--- a/src/content/docs/it/contributing/API-Docs.mdx
+++ b/src/content/docs/it/contributing/API-Docs.mdx
@@ -1,148 +1,135 @@
 ---
-title: API Documentation Guide
+title: Guida alla Documentazione API
 category: guide
-lastUpdated: 2025-01-03 17:26:00
+lastUpdated: 2025-04-27 13:28:00
 layout: /src/layouts/documentation.astro
 ---
 import { FileTree } from '@astrojs/starlight/components';
 import { URLS } from "@/Consts.js";
 
-## Developer FAQs
+## FAQ per Sviluppatori
 
-### How is the project structured?
+### Come è strutturato il progetto?
 
-#### File Structure
+#### Struttura dei File
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory.
-Each file is exposed as a route based on its file name.
+Starlight cerca file `.md` o `.mdx` nella directory `src/content/docs/`.
+Ogni file viene esposto come route basata sul nome del file.
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+Le immagini possono essere aggiunte a `src/assets/` e incorporate nel Markdown con un link relativo.
 
-Static assets, like favicons, can be placed in the `public/` directory.
+Gli asset statici, come le favicon, possono essere posizionati nella directory `public/`.
 
 <FileTree>
-    - public favicons and other static assets
+    - public favicon e altri asset statici
         - ...
     - src
-        - assets Images for doc pages
+        - assets Immagini per le pagine di documentazione
             - ...
-        - components Custom components
+        - components Componenti custom
             - GraphQLExplorer
-                - GraphQLExplorer.astro Main file of the GraphQL Explorer component
+                - GraphQLExplorer.astro File principale del componente GraphQL Explorer
                 - ...
-            - ui shadcn/ui components
+            - ui componenti shadcn/ui
                 - ...
             - ...
         - content
-            - docs mdx files that generates doc pages
+            - docs file mdx che generano pagine di documentazione
                 - api
                     - GraphQL
-                        - Schema Data schemas
+                        - Schema Schema dati
                             - ...
                     - ...
-                    - guides Guides and tutorials
+                    - guides Guide e tutorial
                         - ...
                     - getting-started.mdx
                     - ...
-                - contributing Contributing guidelines
+                - contributing Linee guida per contribuire
                     - ...
-                - it Italian translations
+                - it Traduzioni in italiano
                     - ...
-                -  librarians Librarian guides
+                -  librarians Guide per bibliotecari
                     - ...
-                - ui.json translations for any UI strings
-        - layouts Layouts for doc pages
-            - documentation.astro Main layout for doc pages
+                - ui.json traduzioni per le stringhe UI
+        - layouts Layout per pagine di documentazione
+            - documentation.astro Layout principale per pagine di documentazione
             - ...
-    - astro.config.mjs Astro configuration file
-    - components.json shadcn/ui components
-    - CONTRIBUTING Contributing guidelines
-    - DEVELOPERS.md Developer FAQs
-    - tailwind.config.mjs Tailwind CSS configuration
+    - astro.config.mjs File di configurazione Astro
+    - components.json componenti shadcn/ui
+    - CONTRIBUTING Linee guida per contribuire
+    - DEVELOPERS.md FAQ per sviluppatori
+    - tailwind.config.mjs Configurazione Tailwind CSS
     - ...
 </FileTree>
 
 
-### How do I run the project locally?
+### Come eseguo il progetto in locale?
 
-#### 🚀 Quick Start
+#### 🚀 Avvio Rapido
 
-1. **Clone the repo:**
+1. **Clona il repo:**
 ```bash
 git clone https://github.com/hardcoverapp/hardcover-docs.git
 ```
-2. **Navigate to the project directory:**
+2. **Naviga nella directory del progetto:**
 ```bash
 cd hardcover-docs
 ```
-3. **Install dependencies:**
+3. **Installa le dipendenze:**
  ```bash
  npm install
   ```
-4. **Start the dev server:**
+4. **Avvia il dev server:**
  ```bash
  npm run dev
   ```
-5. **Open your browser**
-6. **Navigate to `http://localhost:4321`**
+5. **Apri il browser**
+6. **Vai a `http://localhost:4321`**
 
-#### 🧞 Commands
+#### 🧞 Comandi
 
-The Hardcover documentation site is built with [Astro](https://astro.build/).
-All commands are run from the root of the project, from a terminal:
+Il sito di documentazione di Hardcover è costruito con [Astro](https://astro.build/).
+Tutti i comandi vengono eseguiti dalla root del progetto, da un terminale:
 
-| Command                              | Action                                           |
-|:-------------------------------------|:-------------------------------------------------|
-| `npm install`                        | Installs dependencies                            |
-| `npm run dev`                        | Starts local dev server at `localhost:4321`      |
-| `npm run build`                      | Build your production site to `./dist/`          |
-| `npm run preview`                    | Preview your build locally, before deploying     |
-| `npm run astro ...`                  | Run CLI commands like `astro add`, `astro check` |
-| `npm run astro -- --help`            | Get help using the Astro CLI                     |
-| `npx vitest`                         | Run the unit tests for the project               |
-| `npx vitest --coverage.enabled true` | Run the unit tests with code coverage            |
+| Comando                              | Azione                                            |
+|:-------------------------------------|:--------------------------------------------------|
+| `npm install`                        | Installa le dipendenze                            |
+| `npm run dev`                        | Avvia il dev server locale su `localhost:4321` |
+| `npm run build`                      | Fai una build di produzione in `./dist/`   |
+| `npm run preview`                    | Vedi un'anteprima della build in locale, prima del deploy |
+| `npm run astro ...`                  | Esegui comandi CLI come `astro add`, `astro check` |
+| `npm run astro -- --help`            | Ottieni aiuto utilizzando la CLI di Astro         |
+| `npx vitest`                         | Esegui gli unit tests per il progetto             |
+| `npx vitest --coverage.enabled true` | Esegui gli unit test con coverage    |
 
-### How do I add a new page or update an existing page?
+### Come aggiungo una nuova pagina o aggiorno una pagina esistente?
 
-#### Adding a New Page
+#### Aggiungere una Nuova Pagina
 
-1. Create a new `.mdx` file in the `src/content/docs/` directory.
-2. Give the file a name that describes the content.
-3. Add [frontmatter](#page-frontmatter) to the top of the file.
-4. Add content to the file using Markdown or MDX syntax.
-5. Add the new page to the sidebar
- - If the page is part of the `api/GraphQL/Schema` or `guides` sections the sidebar will automatically update with the new page.
- - All other pages will need to be added to the astro config file
-see [Starlight - Add links and link groups](https://starlight.astro.build/guides/sidebar/#add-links-and-link-groups)
-for more information.
+1. Crea un nuovo file `.mdx` nella directory `src/content/docs/`.
+2. Dai al file un nome che descriva il contenuto.
+3. Aggiungi il [frontmatter](#page-frontmatter) in cima al file.
+4. Aggiungi contenuto al file utilizzando la sintassi Markdown o MDX.
+5. Aggiungi la nuova pagina alla barra laterale
+ - Se la pagina fa parte delle sezioni `api/GraphQL/Schema` o `guides`, la barra laterale si aggiornerà automaticamente con la nuova pagina.
+ - Tutte le altre pagine dovranno essere aggiunte al file di configurazione astro
+vedi [Starlight - Aggiungi collegamenti e gruppi di collegamenti](https://starlight.astro.build/it/guides/sidebar/#aggiungi-collegamenti-e-gruppi-di-collegamenti)
+per maggiori informazioni.
 
 ##### Page Frontmatter
-Moved to [Frontmatter](./Frontmatter)
+Spostato a [Frontmatter](./Frontmatter)
 
-#### Available Components
-Moved to [Astro Components](./astro-components) for Astro components and [React Components](./react-components) for React components.
+#### Componenti Disponibili
+Spostato a [Astro Components](./astro-components) per i componenti Astro e [React Components](./react-components) per i componenti React.
 
-### How do I add a new language to the language dropdown?
+### Tradurre Contenuto
+Spostato a to [Translating Documentation Guide](./doc-translations)
 
-The root language should **not** be changed from English.
-To add a new language, see [Starlight - Configure i18n](https://starlight.astro.build/guides/i18n/#configure-i18n).
+## Risorse di Supporto
 
-When adding a new language,
-you should also update the existing translations in the astro config file to include the new language.
+### Inviare un Bug Report
 
-### How do I add a translation for an existing language?
+### Richiedere una Funzionalità
 
-Once a language has been added to the astro config file you can create a new file in the `src/content/docs/` directory
-inside a folder named with the language code. This new file should have the same name as the original file you are translating.
-
-For example, if you are translating the `src/content/docs/getting-started.mdx` file into Spanish you would create a new
-file at `src/content/docs/es/getting-started.mdx` with the Spanish translation of the content.
-
-## Support Resources
-
-### Submitting a Bug Report
-
-### Requesting a Feature
-
-### Finding Help on Discord
-Connect with us on <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord</a>
+### Trovare Aiuto su Discord
+Connettiti con noi su <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord</a>

--- a/src/content/docs/it/contributing/Astro-Components.mdx
+++ b/src/content/docs/it/contributing/Astro-Components.mdx
@@ -1,0 +1,91 @@
+---
+title: Componenti Astro
+category: guide
+description: Informazioni sui componenti Astro disponibili nel sito della documentazione.
+lastUpdated: 2025-04-28 11:20:00
+layout: /src/layouts/librarians.astro
+---
+import GraphQLExplorer from '@/components/GraphQLExplorer/GraphQLExplorer.astro';
+import SocialIcons from '@/components/SocialIcons.astro';
+
+## Tipi di Componenti
+Attualmente, ci sono due tipi di componenti disponibili nel sito dells documentazione:
+- [**Componenti Astro**](./astro-components): Questi sono componenti scritti in Astro e vengono utilizzati per creare pagine HTML statiche. Usa questi componenti quando non hai bisogno di interattività lato client. I componenti Astro possono essere utilizzati da altri componenti Astro ma non possono essere utilizzati dai componenti React.
+- [**Componenti React**](./react-components): Questi sono componenti scritti in React e vengono utilizzati per creare pagine dinamiche e interattive. Usa questi componenti quando hai bisogno di interattività lato client o gestione dello stato. I componenti React possono essere utilizzati da altri componenti React e da componenti Astro.
+
+## Scrivere Componenti Astro
+I componenti Astro vengono scritti in file `.astro` nella directory `/src/components`.
+
+## Componenti Astro Disponibili
+Oltre ai componenti standard di [Starlight - Componenti](https://starlight.astro.build/guides/components/), il sito della documentazione di Hardcover include i seguenti componenti personalizzati:
+
+### Explorer GraphQL
+
+Questo componente consente a un utente di visualizzare query GraphQL e sperimentare eseguendole sull'API.
+
+**Percorso di Importazione:**
+```js
+import GraphQLExplorer from '@/components/GraphQLExplorer/GraphQLExplorer.astro';
+```
+
+**Parametri:**
+
+- `canTry` - Un valore booleano che determina se l'utente può eseguire la query nell'explorer. Il valore predefinito è `true`.
+- `description` - Una stringa che descrive la query.
+- `forcePresentation` - Un valore booleano che determina se le opzioni di presentazione devono essere nascoste. Il valore predefinito è `false`.
+- `presentation` - La presentazione predefinita della risposta, può essere `json` o `table`. Il valore predefinito è `json`.
+- `query` - Una stringa contenente la query GraphQL da visualizzare nell'explorer.
+- `title` - Una stringa per il titolo della query mostrata nell'explorer. Il valore predefinito è `Example Query`. Modifica questo valore durante la traduzione della pagina in un'altra lingua.
+
+**Utilizzo:**
+
+```mdx
+<GraphQLExplorer
+    query={query}
+    description="Query di esempio"
+    presentation='table'
+    title="Esempio"
+/>
+```
+
+<GraphQLExplorer query={`
+query {
+    me {
+        id,
+        username
+    }
+}
+`}/>
+
+### Icone Social
+
+Questo componente è principalmente destinato per essere utilizzato internamente, ma può essere utilizzato per visualizzare le icone dei social media di Hardcover.
+
+**Percorso di Importazione:**
+
+```js
+
+import SocialIcons from '@/components/SocialIcons.astro';
+
+```
+
+**Parametri:**
+
+- `iconSize` - Una stringa per la dimensione delle icone. Il valore predefinito è `16px`.
+
+**Utilizzo:**
+
+```mdx
+<div class="flex justify-around h-6 w-80">
+    <SocialIcons iconSize="20px" />
+</div>
+```
+
+<div className="flex justify-around h-6 w-80">
+    <SocialIcons iconSize="20px" />
+</div>
+
+## Limitazioni
+- I componenti Astro vengono renderizzati sul server e non hanno accesso agli oggetti `window` o `document` del browser.
+- I componenti Astro non supportano la gestione dello stato o l'interattività lato client.
+- I componenti Astro non possono essere utilizzati all'interno di componenti React.

--- a/src/content/docs/it/contributing/Doc-Translations.mdx
+++ b/src/content/docs/it/contributing/Doc-Translations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guida alla Traduzione della Documentazione
 category: guide
-lastUpdated: 2025-03-31 16:58:00
+lastUpdated: 2025-04-27 16:59:00
 layout: /src/layouts/librarians.astro
 ---
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/content/docs/it/contributing/Doc-Translations.mdx
+++ b/src/content/docs/it/contributing/Doc-Translations.mdx
@@ -1,54 +1,81 @@
 ---
-title: Translating Documentation Guide
+title: Guida alla Traduzione della Documentazione
 category: guide
-lastUpdated: 2025-02-28 13:27:00
+lastUpdated: 2025-03-31 16:58:00
 layout: /src/layouts/librarians.astro
 ---
-import { Steps } from '@astrojs/starlight/components';
+import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 
-# Translating Exising Pages
+<Tabs>
+    <TabItem label="Aggiornare le Traduzioni per Pagine Esistenti" default>
+        Quando è già presente una traduzione per una pagina, puoi aggiornare la traduzione seguendo questi passaggi:
 
-<Steps>
-    1. Go to the page you want to translate.
+        <Steps>
+            1. Vai alla pagina che desideri tradurre.
 
-    2. Using the language dropdown at the top of the page, select the language you want to translate the document into.
+            2. Utilizzando il menu delle lingue nella parte superiore della pagina, seleziona la lingua in cui desideri tradurre il documento.
 
-    3. Click the "Edit page" button at the bottom of the page.
+            3. Clicca sul pulsante "Modifica pagina" nella parte inferiore della pagina.
 
-    4. Translate the content into the selected language.
+            4. Traduci il contenuto nella lingua selezionata.
 
-    5. After making your changes click the "Commit changes..." button at the top of the page.
+            5. Dopo aver apportato le modifiche, clicca sul pulsante "Commit changes..." nella parte superiore della pagina.
 
-    6. In the modal that appears, add a title and description to describe your changes, then click the "Propose changes" button.
+            6. Nella finestra modale che appare, aggiungi un titolo e una descrizione per descrivere le tue modifiche, quindi clicca sul pulsante "Propose changes".
 
-    7. In Discord ping `@Revelry` to review your changes.
+            7. Su Discord menziona `@Revelry` per rivedere le tue modifiche.
 
-</Steps>
+        </Steps>
+    </TabItem>
+    <TabItem label="Aggiungere una Pagina a una Traduzione Esistente">
+        Durante la navigazione del sito della documentazione, potresti trovare una pagina che non è tradotta nella lingua che stai visualizzando.
+        In questo caso potresti vedere un banner nella parte superiore della pagina simile a quello qui sotto:
 
+        <img src="/images/Translation-Not-Found-IT.png" alt="Traduzione Non Trovata" />
 
-# How to reference UI elements in translations
+        Se vedi questo banner, dovrai creare una copia della pagina nella directory di traduzione per la lingua che stai visualizzando,
+        e poi seguire i passaggi descritti in `Aggiornare le Traduzioni per Pagine Esistenti`.
 
-Since the Hardcover app is currently only available in English,
-you should write the documentation pages with the English labels but also include what the translation should be.
+        Una volta che una lingua è stata aggiunta al file di configurazione astro, puoi creare un nuovo file nella directory `src/content/docs/`
+        all'interno di una cartella denominata con il codice della lingua. Questo nuovo file deve avere lo stesso nome del file originale che stai traducendo.
 
-For example, if you are translating a page that references a button with the label "Save",
-you should write the page with the button labeled as "Save" and include the translation in the page content like so:
+        Ad esempio, se stai traducendo il file `src/content/docs/getting-started.mdx` in spagnolo, creeresti un nuovo
+        file in `src/content/docs/es/getting-started.mdx` con la traduzione spagnola del contenuto.
+
+        Istruzioni più dettagliate al riguardo saranno aggiunte in futuro.
+
+    </TabItem>
+
+</Tabs>
+
+## Aggiungere nuove lingue al menu delle lingue
+
+Se desideri aggiungere una nuova lingua che non è attualmente disponibile nel menu delle lingue,
+puoi farlo seguendo questi passaggi:
+
+Per maggiori informazioni, vedi [Starlight - Configurare i18n](https://starlight.astro.build/it/guides/i18n/#configurare-i18n).
+
+### Note Importanti
+- La lingua principale **non** deve essere cambiata dall'inglese.
+- Quando aggiungi una nuova lingua, dovresti anche aggiornare i blocchi di traduzione esistenti nel file di configurazione astro per includere la nuova lingua.
+
+## Come fare riferimento agli elementi dell'interfaccia utente nelle traduzioni
+
+Poiché l'app Hardcover è attualmente disponibile solo in inglese,
+dovresti scrivere le pagine di documentazione con le etichette in inglese ma includere anche quale dovrebbe essere la traduzione.
+
+Ad esempio, se stai traducendo una pagina che fa riferimento a un pulsante con l'etichetta "Save",
+dovresti scrivere la pagina con il pulsante etichettato come "Save" e includere la traduzione nel contenuto della pagina come segue:
 
 ```
 Click the <kbd>Save</kbd> button to save your changes.
 ```
 
-Would become:
+Diventerebbe:
 
 ```
-Haga clic en el botón <kbd>Save</kbd> "Guardar" para guardar los cambios.
-
+Clicca sul pulsante <kbd>Save</kbd> "Salva" per salvare le tue modifiche.
 ```
 
-# Adding new languages to the language dropdown
-
-The root language should **not** be changed from English.
-To add a new language, see [Starlight - Configure i18n](https://starlight.astro.build/guides/i18n/#configure-i18n).
-
-When adding a new language,
-you should also update the existing translations in the astro config file to include the new language.
+## Utilizzare le nuove traduzioni
+Vedi [Utilizzare le Traduzioni nelle Pagine della Documentazione](./using-translations) per maggiori informazioni su come utilizzare le nuove traduzioni nelle pagine di documentazione.

--- a/src/content/docs/it/contributing/Frontmatter.mdx
+++ b/src/content/docs/it/contributing/Frontmatter.mdx
@@ -2,7 +2,7 @@
 title: Frontmatter
 category: guide
 description: Informazioni sul frontmatter utilizzato nelle pagine della documentazione.
-lastUpdated: 2025-03-29 13:48:00
+lastUpdated: 2025-04-28 13:48:00
 layout: /src/layouts/librarians.astro
 ---
 

--- a/src/content/docs/it/contributing/Frontmatter.mdx
+++ b/src/content/docs/it/contributing/Frontmatter.mdx
@@ -1,0 +1,47 @@
+---
+title: Frontmatter
+category: guide
+description: Informazioni sul frontmatter utilizzato nelle pagine della documentazione.
+lastUpdated: 2025-03-29 13:48:00
+layout: /src/layouts/librarians.astro
+---
+
+## Cos'è il `Frontmatter`?
+Il Frontmatter è un blocco di metadati all'inizio di un file Markdown che fornisce informazioni sulla pagina.
+Viene utilizzato da Starlight per generare le pagine HTML e può essere usato per controllare vari aspetti del comportamento e dell'aspetto della pagina.
+
+## Quali opzioni sono disponibili?
+Le seguenti opzioni sono disponibili nel frontmatter delle pagine:
+
+Vedi [Starlight -
+Frontmatter](https://starlight.astro.build/it/reference/frontmatter/) per ulteriori informazioni e opzioni aggiuntive.
+
+| Campo           | Descrizione                                                                                                                                                                             | Obbligatorio |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| title           | Stringa contenente il titolo della pagina                                                                                                                                               | Sì          |
+| category        | Stringa della categoria in cui la pagina deve essere inclusa `guide` o `reference`                                                                                                      | Sì          |
+| layout          | Percorso relativo di uno dei layout in `/src/layouts`                                                                                                                                   | Sì          |
+| description     | Stringa contenente la descrizione da utilizzare nei meta tag HTML                                                                                                                 | Consigliato |
+| lastUpdated     | Stringa nel formato `YYYY-MM-DD HH:MM:SS`                                                                                                                                               | Consigliato |
+| draft           | Valore booleano che determina se la pagina debba essere nascosta dal sito di produzione                                                                                                 | No          |
+| slug            | Stringa contenente lo slug dell'URL per la pagina                                                                                                                                       | No          |
+| tableOfContents | Valore booleano che determina se debba essere generata una tabella dei contenuti                                                                                                        | No          |
+| template        | `doc` o `splash` predefinito è `doc`. `splash` è un layout più ampio senza le barre laterali normali                                                                                   | No          |
+| hero            | Vedi [Starlight - Frontmatter HeroConfig](https://starlight.astro.build/it/reference/frontmatter/#heroconfig) per ulteriori informazioni                                                   | No          |
+| banner          | Vedi [Starlight - Frontmatter Banner](https://starlight.astro.build/reference/frontmatter/#banner) per ulteriori informazioni                                                           | No          |
+| prev            | Valore booleano che determina se debba essere mostrato un pulsante di collegamento alla pagina precedente. Vedi [Starlight - Frontmatter Prev](https://starlight.astro.build/it/reference/frontmatter/#prev) per ulteriori informazioni | No          |
+| next            | Valore booleano che determina se debba essere mostrato un pulsante di collegamento alla pagina successiva. Vedi [Starlight - Frontmatter Next](https://starlight.astro.build/it/reference/frontmatter/#next) per ulteriori informazioni | No          |
+| sidebar         | Controlla come la pagina viene visualizzata nella barra laterale. Vedi [Starlight - Frontmatter Sidebar](https://starlight.astro.build/it/reference/frontmatter/#sidebarconfig) per ulteriori informazioni | No          |
+
+
+### Esempio di Frontmatter
+
+```md
+---
+title: Introduzione all'API
+description: Inizia a utilizzare l'API GraphQL di Hardcover.
+category: guide
+lastUpdated: 2025-02-01 17:03:00
+layout: ../../layouts/documentation.astro
+---
+```

--- a/src/content/docs/it/contributing/Librarian-Guides.mdx
+++ b/src/content/docs/it/contributing/Librarian-Guides.mdx
@@ -1,147 +1,121 @@
 ---
-title: Librarian Contribution Guide
+title: Guida alla Contribuzione per Bibliotecari
 category: guide
-lastUpdated: 2025-01-06 16:01:00
+lastUpdated: 2025-04-27 14:19:00
 layout: /src/layouts/librarians.astro
 ---
 
 import { URLS } from "@/Consts.js";
 
-# Librarian Contribution Guide
-## Ways to Contribute
-We are currently looking for contributions in the following areas:
+# Guida alla Contribuzione per Bibliotecari
+## Modi per Contribuire
+Attualmente stiamo cercando contributi nelle seguenti aree:
 
-- API Documentation: Help us improve the API documentation by adding new pages or updating existing content.
-- API Guides: Share your knowledge by writing guides on how to use the Hardcover API.
-- Bug Fixes: Help us fix bugs in the documentation site.
-- Reporting Issues: Report any issues you encounter with the documentation site. <a href={URLS.CREATE_ISSUE} target="_blank" rel="noreferrer noopener">Create Issue</a>
-- Feature Requests: Share your ideas for new features or improvements to the documentation site. <a href={URLS.SUGGEST_FEATURE} target="_blank" rel="noreferrer noopener">Suggest Feature</a>
-- Librarian Guides: Share your expertise by writing guides on how to use the Librarian tools.
+- Documentazione API: Aiutaci a migliorare la documentazione API aggiungendo nuove pagine o aggiornando i contenuti esistenti.
+- Guide API: Condividi ciò che conosci scrivendo guide su come utilizzare l'API di Hardcover.
+- Correzione Bug: Aiutaci a correggere bug nel sito della documentazione.
+- Segnalazione Problemi: Segnala qualsiasi problema riscontrato con il sito della documentazione. <a href={URLS.CREATE_ISSUE} target="_blank" rel="noreferrer noopener">Crea Issue</a>
+- Richiesta Funzionalità: Condividi le tue idee per nuove funzionalità o miglioramenti al sito della documentazione. <a href={URLS.SUGGEST_FEATURE} target="_blank" rel="noreferrer noopener">Suggerisci Funzionalità</a>
+- Guide per Bibliotecari: Condividi le tue competenze scrivendo guide su come utilizzare gli strumenti per Bibliotecari.
 
-## Finding Something to Work On
-You can find issues to work on
-by looking at the <a href={URLS.ISSUES} target="_blank" rel="noreferrer noopener">Issues Board</a> on GitHub
-or by joining the <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Hardcover Discord</a> and asking for suggestions in the <a href={URLS.API_DISCORD} target="_blank"
-rel="noreferrer noopener">#API</a> or <a href={URLS.LIBRARIAN_DISCORD} target="_blank"
-rel="noreferrer noopener">#librarians</a> channels.
+## Trovare Qualcosa su cui Lavorare
+Per trovare problemi su cui lavorare puoi guardare la <a href={URLS.ISSUES} target="_blank" rel="noreferrer noopener">Bacheca degli Issues</a> su GitHub
+o unirti al <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord di Hardcover</a> e chiedendo suggerimenti nei canali <a href={URLS.API_DISCORD} target="_blank"
+rel="noreferrer noopener">#API</a> o <a href={URLS.LIBRARIAN_DISCORD} target="_blank"
+rel="noreferrer noopener">#librarians</a>.
 
-## Being a Good Contributor
-When contributing to Hardcover, please follow these guidelines:
+## Essere un Buon Contributore
+Quando contribuisci a Hardcover, segui queste linee guida:
 
-- Be respectful of others and their contributions.
-- Be open to feedback and willing to make changes based on feedback.
-- Be patient and understanding of the time it takes to review and merge contributions.
-- Be clear and concise in your contributions.
-- Be willing to help others and answer questions.
-- Be willing to work with others to improve the documentation site.
-- Be open to learning and growing as a contributor.
-- Be willing to follow the contribution processes.
-- Be willing to accept that not all contributions will be accepted.
+- Sii rispettoso degli altri e dei loro contributi.
+- Sii aperto al feedback e disposto a fare cambiamenti basati sul feedback.
+- Sii paziente e comprensivo riguardo al tempo necessario per revisionare e fare merge dei contributi.
+- Sii chiaro e conciso nei tuoi contributi.
+- Sii disposto ad aiutare gli altri e rispondere alle domande.
+- Sii disposto a lavorare con altri per migliorare il sito della documentazione.
+- Sii aperto all'apprendimento e alla crescita come contributore.
+- Sii disposto a seguire i processi di contribuzione.
+- Sii disposto ad accettare che non tutti i contributi saranno accettati.
 
-## How do I add a new page or update an existing page?
-### Adding a New Page
-1. Navigate to the <a href={URLS.GITHUB} target="_blank" rel="noreferrer noopener">Hardcover Docs GitHub</a>
-2. Navigate to the `src/content/docs/` directory.
-3. Navigate to the appropriate subdirectory for the page you want to add.
-4. Click the "Add file" button near the top right of the file list.
-5. Click the "Create new file" option.
-6. In the editor that opens, give the new file a meaningful name ending in `.mdx`, see the existing files for examples.
-7. Add the [frontmatter](#page-frontmatter) to the new page using the template below.
-8. Provide the content for the new page using [Markdown](https://www.markdownguide.org/cheat-sheet/) or [MDX](https://mdxjs.com/guides/) syntax.
-9. Preview your changes for formatting and accuracy.
-10. Click the "Commit changes..." button at the top of the page.
-11. In the dialog that opens, provide a title and description for your changes.
-12. Ensure the "Create a new branch for this commit and start a pull request" option is selected.
-13. Give your branch a short, descriptive name.
-14. Click the "Propose changes" button to save your changes.
-15. Notify the Hardcover team, namely `@revelry` in the <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Hardcover Discord</a> that you have submitted a pull request.
-16. Wait for feedback and review from the Hardcover team.
-17. Make any requested changes.
-18. Once your pull request is approved, it will be merged into the main branch.
-19. Celebrate your contribution!
-20. Continue contributing to Hardcover!
+## Come aggiungo una nuova pagina o aggiorno una pagina esistente?
+### Aggiungere una Nuova Pagina
+1. Naviga alla pagina <a href={URLS.GITHUB} target="_blank" rel="noreferrer noopener">GitHub della Documentazione di Hardcover</a>
+2. Naviga alla directory `src/content/docs/`.
+3. Naviga alla sottodirectory della pagina che vuoi aggiungere.
+4. Clicca sul pulsante "Add file" nella parte superiore destra dell'elenco dei file.
+5. Clicca sull'opzione "Create new file".
+6. Nell'editor che si apre, dai al nuovo file un nome significativo che termini con `.mdx`, controlla i file esistenti per vedere degli esempi.
+7. Aggiungi il [frontmatter](#page-frontmatter) alla nuova pagina utilizzando il template sottostante.
+8. Fornisci il contenuto per la nuova pagina utilizzando la sintassi [Markdown](https://www.markdownguide.org/cheat-sheet/) o [MDX](https://mdxjs.com/guides/).
+9. Visualizza un'anteprima delle tue modifiche per verificare formattazione e accuratezza.
+10. Clicca sul pulsante "Commit changes..." nella parte superiore della pagina.
+11. Nella finestra di dialogo che si apre, fornisci un titolo e una descrizione per le tue modifiche.
+12. Assicurati che l'opzione "Create a new branch for this commit and start a pull request" sia selezionata.
+13. Dai al tuo branch un nome breve e descrittivo.
+14. Clicca sul pulsante "Propose changes" per salvare le tue modifiche.
+15. Notifica il team di Hardcover, in particolare `@revelry` nel <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord di Hardcover</a> comunicando che hai inviato una pull request.
+16. Attendi una revisione e feedback dal team di Hardcover.
+17. Apporta eventuali modifiche richieste.
+18. Una volta che la tua pull request è approvata, sarà unita al branch principale.
+19. Festeggia il tuo contributo!
+20. Continua a contribuire a Hardcover!
 
-### Editing an Existing Page
-1. Using the UI navigate to the page, you want to edit.
-2. Click the "Edit page" button near the bottom of the content.
-3. In the GitHub page that opens, click the pencil icon on the top right of the file to start editing.
-4. Make your changes in the editor using [Markdown](https://www.markdownguide.org/cheat-sheet/) or [MDX](https://mdxjs.com/guides/) syntax.
-5. Update the [frontmatter](#page-frontmatter) as needed using the template below, make sure to update the `lastUpdated` field.
-6. Preview your changes for formatting and accuracy.
-7. Click the "Commit changes..." button at the top of the page.
-8. In the dialog that opens, provide a title and description for your changes.
-9. Ensure the "Create a new branch for this commit and start a pull request" option is selected.
-10. Give your branch a short, descriptive name.
-11. Click the "Propose changes" button to save your changes.
-12. Notify the Hardcover team, namely `@revelry` in the <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Hardcover Discord</a> that you have submitted a pull request.
-13. Wait for feedback and review from the Hardcover team.
-14. Make any requested changes.
-15. Once your pull request is approved, it will be merged into the main branch.
-16. Celebrate your contribution!
-17. Continue contributing to Hardcover!
+### Modificare una Pagina Esistente
+1. Utilizzando l'interfaccia utente, naviga alla pagina che desideri modificare.
+2. Clicca sul pulsante "Modifica paigina" nella parte inferiore del contenuto.
+3. Nella pagina GitHub che si apre, clicca sull'icona della matita nella parte superiore destra del file per iniziare a modificare.
+4. Apporta le tue modifiche nell'editor utilizzando la sintassi [Markdown](https://www.markdownguide.org/cheat-sheet/) o [MDX](https://mdxjs.com/guides/).
+5. Aggiorna il [frontmatter](#page-frontmatter) utilizzando il modello sottostante, assicurati di aggiornare il campo `lastUpdated`.
+6. Visualizza un'anteprima delle tue modifiche per verificare formattazione e accuratezza.
+7. Clicca sul pulsante "Commit changes..." nella parte superiore della pagina.
+8. Nella finestra di dialogo che si apre, fornisci un titolo e una descrizione per le tue modifiche.
+9. Assicurati che l'opzione "Create a new branch for this commit and start a pull request" sia selezionata.
+10. Dai al tuo branch un nome breve e descrittivo.
+11. Clicca sul pulsante "Propose changes" per salvare le tue modifiche.
+12. Notifica il team di Hardcover, in particolare `@revelry` nel <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord di Hardcover</a> comunicando che hai inviato una pull request.
+13. Attendi la revisione e feedback dal team di Hardcover.
+14. Apporta eventuali modifiche richieste.
+15. Una volta che la tua pull request è approvata, sarà unita al branch principale.
+16. Festeggia il tuo contributo!
+17. Continua a contribuire a Hardcover!
 
-## Adding Images
-Currently, images have to be added as a separate pull request. To add an image:
+## Aggiungere Immagini
+Attualmente, le immagini devono essere aggiunte tramite una pull request separata. Per aggiungere un'immagine:
 
-1. Navigate to the <a href={URLS.GITHUB} target="_blank" rel="noreferrer noopener">Hardcover Docs Github</a>
-2. Navigate to the `public/images/` directory.
-3. Navigate to the appropriate subdirectory `api` or `librarians` depending on where the image will be used.
-4. Click the "Add file" button near the top right of the file list.
-5. Click the "Upload files" option.
-6. Drag and drop the image file(s) into the upload area.
-7. In the Commit changes section, provide a title and description for your changes.
-8. Ensure the "Create a new branch for this commit and start a pull request" option is selected.
-9. Give your branch a short, descriptive name.
-10. Click the "Propose changes" button to save your changes.
-11. Notify the Hardcover team, namely `@revelry` in the <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Hardcover Discord</a> that you have submitted a pull request.
-12. Wait for feedback and review from the Hardcover team.
-13. Make any requested changes.
-14. Once your pull request is approved, it will be merged into the main branch.
-15. After the image is merged, follow the steps in the [Editing an Existing Page](#editing-an-existing-page) section to add the image to and reference it using the relative path: `/images/subdirectory/your-image.png`.
+1. Naviga alla pagine <a href={URLS.GITHUB} target="_blank" rel="noreferrer noopener">GitHub della Documentazione di Hardcover</a>
+2. Naviga alla directory `public/images/`.
+3. Naviga alla sottodirectory `api` o `librarians` a seconda di dove verrà utilizzata l'immagine.
+4. Clicca sul pulsante "Add file" nella parte superiore destra dell'elenco dei file.
+5. Clicca sull'opzione "Upload files".
+6. Trascina e rilascia i file immagine nell'area di caricamento.
+7. Nella sezione Commit changes, fornisci un titolo e una descrizione per le tue modifiche.
+8. Assicurati che l'opzione "Create a new branch for this commit and start a pull request" sia selezionata.
+9. Dai al tuo branch un nome breve e descrittivo.
+10. Clicca sul pulsante "Propose changes" per salvare le tue modifiche.
+11. Notifica il team di Hardcover, in particolare `@revelry` nel <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord di Hardcover</a> comunicando che hai inviato una pull request.
+12. Attendi la revisione e feedback dal team di Hardcover.
+13. Apporta eventuali modifiche richieste.
+14. Una volta che la tua pull request è approvata, sarà unita al branch principale.
+15. Dopo che l'immagine è stata unita, segui i passaggi nella sezione [Modificare una Pagina Esistente](#editing-an-existing-page) per aggiungere l'immagine e farvi riferimento utilizzando il percorso relativo: `/images/subdirectory/your-image.png`.
 
 ```md
-<img src="/images/librarians/long-title-example.png" alt="Example of a long title on Hardcover" />
+<img src="/images/librarians/long-title-example.png" alt="Esempio di un titolo lungo su Hardcover" />
 ```
 
 ## Page Frontmatter
+Spostato in [Frontmatter](./Frontmatter)
 
-| Field           | Description                                                                                                                                                                             | Required    |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| title           | String containing the title of the page                                                                                                                                                 | Yes         |
-| category        | String of the category the page should be included in `guide` or `reference`                                                                                                            | Yes         |
-| layout          | relative path to `/src/layouts/documentation.astro`                                                                                                                                     | Yes         |
-| description     | String containing the descriptive text to use in HTML meta tags                                                                                                                         | Recommended |
-| lastUpdated     | String in the format `YYYY-MM-DD HH:MM:SS`                                                                                                                                              | Recommended |
-| draft           | Boolean value determining whether the page should be hidden from the production site                                                                                                    | No          |
-| slug            | String containing the URL slug for the page                                                                                                                                             | No          |
-| tableOfContents | Boolean value determining whether a table of contents should be generated                                                                                                               | No          |
-| template        | `doc` or `splash` default is `doc`. `splash` is a wider layout without the normal sidebars                                                                                              | No          |
-| hero            | See [Starlight - Frontmatter HeroConfig](https://starlight.astro.build/reference/frontmatter/#heroconfig) for more information                                                          | No          |
-| banner          | See [Starlight - Frontmatter Banner](https://starlight.astro.build/reference/frontmatter/#banner) for more information                                                                  | No          |
-| prev            | Boolean value determining whether a previous button should be shown. See [Starlight - Frontmatter Prev](https://starlight.astro.build/reference/frontmatter/#prev) for more information | No          |
-| next            | Boolean value determining whether a next button should be shown. See [Starlight - Frontmatter Next](https://starlight.astro.build/reference/frontmatter/#next) for more information     | No          |
-| sidebar         | Control how the page is displayed in the sidebar. See [Starlight - Frontmatter Sidebar](https://starlight.astro.build/reference/frontmatter/#sidebarconfig) for more information        | No          |
+## Componenti Disponibili
+Spostato in [Astro Components](./astro-components) per i componenti Astro e [React Components](./react-components) per i componenti React.
 
-### Example Frontmatter
+## Supporto per le Traduzioni
+Sebbene attualmente supportiamo solo l'inglese, siamo aperti ad aggiungere traduzioni in futuro.
+Se sei interessato a contribuire con traduzioni,
+contatta il team di Hardcover nei canali <a href={URLS.API_DISCORD} target="_blank" rel="noreferrer noopener">#API</a>
+o <a href={URLS.LIBRARIAN_DISCORD} target="_blank" rel="noreferrer noopener">#librarians</a> sul <a href={URLS.DISCORD} target="_blank"
+rel="noreferrer noopener">Discord di Hardcover</a>.
 
-```md
----
-title: Getting Started with the API
-description: Get started with the Hardcover GraphQL API.
-category: guide
-lastUpdated: 2025-02-01 17:03:00
-layout: ../../layouts/documentation.astro
----
-```
+## Risorse di Supporto
 
-## Translation Support
-While we currently only support English, we are open to adding translations in the future.
-If you are interested in contributing translations,
-please reach out to the Hardcover team in the <a href={URLS.API_DISCORD} target="_blank" rel="noreferrer noopener">#API</a>
-or <a href={URLS.LIBRARIAN_DISCORD} target="_blank" rel="noreferrer noopener">#librarians</a> channels on the <a href={URLS.DISCORD} target="_blank"
-rel="noreferrer noopener">Hardcover Discord</a>.
-
-## Support Resources
-
-### Finding Help on Discord
-Connect with us on <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord</a>
+### Trovare Aiuto su Discord
+Connettiti con noi su <a href={URLS.DISCORD} target="_blank" rel="noreferrer noopener">Discord</a>

--- a/src/content/docs/it/contributing/React-Components.mdx
+++ b/src/content/docs/it/contributing/React-Components.mdx
@@ -1,5 +1,5 @@
 ---
-title: Guida Componenti React
+title: Componenti React
 category: guide
 description: Informazioni sui componenti React disponibili nel sito della documentazione.
 lastUpdated: 2025-04-27 17:42:00

--- a/src/content/docs/it/contributing/React-Components.mdx
+++ b/src/content/docs/it/contributing/React-Components.mdx
@@ -1,0 +1,30 @@
+---
+title: Guida Componenti React
+category: guide
+description: Informazioni sui componenti React disponibili nel sito della documentazione.
+lastUpdated: 2025-04-27 17:42:00
+layout: /src/layouts/librarians.astro
+---
+
+## Tipi di Componenti
+Attualmente, ci sono due tipi di componenti disponibili nel sito dells documentazione:
+- [**Componenti Astro**](./astro-components): Questi sono componenti scritti in Astro e vengono utilizzati per creare pagine HTML statiche. Usa questi componenti quando non hai bisogno di interattività lato client. I componenti Astro possono essere utilizzati da altri componenti Astro ma non possono essere utilizzati dai componenti React.
+- [**Componenti React**](./react-components): Questi sono componenti scritti in React e vengono utilizzati per creare pagine dinamiche e interattive. Usa questi componenti quando hai bisogno di interattività lato client o gestione dello stato. I componenti React possono essere utilizzati da altri componenti React e da componenti Astro.
+
+## Scrivere Componenti React
+- I componenti React sono definiti in file `.tsx` nella directory `/src/components`.
+- Puoi utilizzare le funzioni utility `useTranslation` e `useTokenTranslation` da `@/lib/utils` per tradurre le stringhe nei componenti React.
+Vedi [Utilizzare le Traduzioni nelle Pagine della Documentazione](./using-translations) per maggiori informazioni su come utilizzare le traduzioni nei componenti React.
+
+## Componenti React Disponibili
+
+### Componenti UI
+
+### Banner
+### Banner di Disclaimer API
+
+### Banner degli Standard per Bibliotecari
+
+### Esploratore GraphQL
+
+Questi componenti verranno presto sostituiti e saranno documentati in futuro.

--- a/src/content/docs/it/contributing/Using-Translations.mdx
+++ b/src/content/docs/it/contributing/Using-Translations.mdx
@@ -1,0 +1,62 @@
+---
+title: Utilizzare le Traduzioni nelle Pagine della Documentazione
+category: guide
+description: Documentazione tecnica su come utilizzare le traduzioni nelle pagine di documentazione.
+lastUpdated: 2025-04-28 16:13:00
+layout: /src/layouts/librarians.astro
+---
+
+Questo documento è rilevante quando stai costruendo nuovi componenti o espandendo quelli esistenti. Non va utilizzato per tradurre le pagine di documentazione.
+
+Vedi [Guida alla Traduzione della Documentazione](./doc-translations) per ulteriori informazioni su come tradurre le pagine di documentazione.
+
+## Utilizzare le Traduzioni nei Componenti React
+Quando si utilizzano le traduzioni nei componenti React, puoi utilizzare la funzione utility `useTranslation` da `@/lib/utils` per tradurre le stringhe.
+Questa funzione accetta una stringa come argomento e restituisce la stringa tradotta in base alla lingua fornita.
+
+Attualmente, le traduzioni devono essere definite nel file `src/content/docs/{LANG}/ui.json`, dove `{LANG}` è il codice della lingua per la traduzione.
+
+### Esempio Base
+```ts
+import React from "react";
+import { useTranslation } from '@/lib/utils';
+
+const MyComponent = () => {
+  return (
+    <div>
+      <h1>{useTranslation('pages.api.disclaimerBanner.title', locale)}</h1>
+    </div>
+  );
+};
+```
+
+### Utilizzare Token Dinamici
+Puoi utilizzare anche token dinamici in una stringa di traduzione.<br/>
+Tuttavia, la stringa restituita dovrà essere sanitizzata prima di essere renderizzata.
+
+#### Esempio
+```ts
+import {URLS} from "@/Consts";
+import {useTokenTranslation} from "@/lib/utils.ts";
+import DOMPurify from "dompurify";
+import React from "react";
+
+const MyComponent = (locale: string = 'en') => {
+    const disclaimerText: string | Node = useTokenTranslation('pages.api.disclaimerBanner.title', locale, {
+        "a": (chunks: any) => {
+            return `<a href=${URLS.API_DISCORD}
+                   target="_blank" rel="noreferrer noopener">{chunks}</a>`
+        }
+    });
+
+    const sanitizedText = () => ({
+        __html: DOMPurify.sanitize(disclaimerText)
+    });
+    
+    return (
+        <div>
+            <h1>{sanitizedText()}</h1>
+        </div>
+    );
+};
+```

--- a/src/content/docs/it/ui.json
+++ b/src/content/docs/it/ui.json
@@ -28,11 +28,11 @@
       "title": "Guide alla Contribuzione",
       "api": "Guida alla Documentazione API",
       "astroComponents": "Guida Componenti Astro",
-      "frontmatter": "Frontmatter Guide",
+      "frontmatter": "Guida Frontmatter",
       "librarian": "Guida alle Contribuzioni dei Bibliotecari",
       "reactComponents": "Guida Componenti React",
       "translations": "Guida alla Traduzione della Documentazione",
-      "usingTranslations": "Using Translations in Doc Pages"
+      "usingTranslations": "Utilizzare le Traduzioni nelle Pagine della Documentazione"
     },
     "librarians": {
       "title": "Guide per Bibliotecari",

--- a/src/content/docs/it/ui.json
+++ b/src/content/docs/it/ui.json
@@ -27,7 +27,7 @@
     "contributing": {
       "title": "Guide alla Contribuzione",
       "api": "Guida alla Documentazione API",
-      "astroComponents": "Astro Components Guide",
+      "astroComponents": "Guida Componenti Astro",
       "frontmatter": "Frontmatter Guide",
       "librarian": "Guida alle Contribuzioni dei Bibliotecari",
       "reactComponents": "Guida Componenti React",

--- a/src/content/docs/it/ui.json
+++ b/src/content/docs/it/ui.json
@@ -30,7 +30,7 @@
       "astroComponents": "Astro Components Guide",
       "frontmatter": "Frontmatter Guide",
       "librarian": "Guida alle Contribuzioni dei Bibliotecari",
-      "reactComponents": "React Components Guide",
+      "reactComponents": "Guida Componenti React",
       "translations": "Guida alla Traduzione della Documentazione",
       "usingTranslations": "Using Translations in Doc Pages"
     },


### PR DESCRIPTION
# Description
This PR translates the Contributing Guides files in Italian:

  - API Docs
  - Astro Components
  - Doc Translations
  - Frontmatter
  - Librarian Guides
  - React Components
  - Using Translations

# Types of changes
- [x] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.
