### PR TITLE
Fix Librarian Application Link

### DIFF
--- a/src/Consts.ts
+++ b/src/Consts.ts
@@ -16,6 +16,7 @@ export const URLS = {
     DISCORD: 'https://discord.gg/edGpYN8ym8',
     API_DISCORD: 'https://discord.com/channels/835558721115389962/1278040045324075050',
     LIBRARIAN_DISCORD: 'https://discord.com/channels/835558721115389962/1105918193022812282',
+    LIBRARIAN_APPLICATION: 'https://hardcover.app/librarians/apply',
 
     APP_STORE: 'https://apps.apple.com/us/app/hardcover-app/id1663379893',
     PLAY_STORE: 'https://play.google.com/store/apps/details?id=hardcover.app',

--- a/src/content/docs/it/librarians/FAQ.mdx
+++ b/src/content/docs/it/librarians/FAQ.mdx
@@ -20,7 +20,7 @@ Sì, per favore fallo: Hardcover sarebbe felice di avere il tuo supporto! I sost
 ## Accesso
 
 ### Come si diventa bibliotecari?
-https://hardcover.app/librarian/apply
+{URLS.LIBRARIAN_APPLICATION}
 
 ### Come posso unirmi al Discord di Hardcover per Bibliotecari?
 Le istruzioni sono [qui](https://hardcover.app/pages/how-to-link-hardcover-roles-with-discord).

--- a/src/content/docs/librarians/FAQ.mdx
+++ b/src/content/docs/librarians/FAQ.mdx
@@ -21,7 +21,7 @@ Supporters retain the full edit permissions of a librarian, but also get a few e
 ## Access
 
 ### How do you become a librarian?
-https://hardcover.app/librarian/apply
+{URLS.LIBRARIAN_APPLICATION}
 
 ### How do I join the Hardcover Discord for Librarians?
 Instructions are [here](https://hardcover.app/pages/how-to-link-hardcover-roles-with-discord).


### PR DESCRIPTION
# Description
Added [librarian application link](https://hardcover.app/librarians/apply) to links in constants and corrected 'librarians' to 'librarian'

# Types of changes
- [x] Broken link

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.
