### PR TITLE
Update Getting-Started.mdx - Incorrect reference

### DIFF
--- a/src/content/docs/api/Getting-Started.mdx
+++ b/src/content/docs/api/Getting-Started.mdx
@@ -38,7 +38,7 @@ After you have your token, you can start making requests to the API.
 
 ## Making Your First Request
 After you have your token, you can head over to the [GraphQL console](https://cloud.hasura.io/public/graphiql?endpoint=https://api.hardcover.app/v1/graphql).
-Next, add a header just called "authorization" (no quotes) with your token as the value.
+Next, add a **header** just called `authorization` with your token as the value.
 
 Tab out of the field, and you should see a list of available resources.
 


### PR DESCRIPTION
# Description
Include a summary of the change, relevant motivation, context, and images/videos.
API docs had the wrong reference for the `Authorization` field.

It state `Authorization Token` which results with the error 

```json
{
  "errors": [
    {
      "message": "Failed to execute 'fetch' on 'Window': Invalid name",
      "stack": "TypeError: Invalid name\n    at fetch (https://cloud.hasura.io/public-graphiql/static/js/main.1dbb5e19.js:2:203246)\n    at https://cloud.hasura.io/public-graphiql/static/js/main.1dbb5e19.js:2:197788\n    at Generator.next (<anonymous>)\n    at s (https://cloud.hasura.io/public-graphiql/static/js/main.1dbb5e19.js:2:196790)\n    at https://cloud.hasura.io/public-graphiql/static/js/main.1dbb5e19.js:2:196751\n    at new Promise (<anonymous>)\n    at i.<computed>.r.<computed> [as next] (https://cloud.hasura.io/public-graphiql/static/js/main.1dbb5e19.js:2:196703)\n    at https://cloud.hasura.io/public-graphiql/static/js/main.1dbb5e19.js:2:161135"
    }
  ]
}
```

# Hardcover or Discord Username
CountMancy in discord and countmancy in hardcover.app

# Types of changes
- [ ] New content
- [x] Updated content
- [ ] Deleted content
- [ ] Broken link
- [x] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [ ] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.

# How to test it?
Go to https://cloud.hasura.io/public/graphiql?endpoint=https://api.hardcover.app/v1/graphql

and create a new field for `Authorization Token`, populate your api key and observer the error.

Switch the field to `Authorization` and receive a response from the api.
