### PR TITLE
Update query for getting user books library

### DIFF
--- a/src/content/docs/api/GraphQL/Schemas/Books.mdx
+++ b/src/content/docs/api/GraphQL/Schemas/Books.mdx
@@ -1,7 +1,7 @@
 ---
 title: Books
 category: reference
-lastUpdated: 2025-03-07 14:20:00
+lastUpdated: 2025-08-13
 layout: /src/layouts/documentation.astro
 ---
 
@@ -229,15 +229,13 @@ import GraphQLExplorer from '@/components/GraphQLExplorer/GraphQLExplorer.astro'
     </tbody>
 </table>
 
-## Get a list of books belonging to the current user
+## Get a List of Books in a User’s Library
 
 <GraphQLExplorer query={`
 {
-      list_books(
+      user_books(
             where: {
-                user_books: {
-                    user_id: {_eq: ##USER_ID##}
-                }
+                user_id: {_eq: ##USER_ID##}
             },
             distinct_on: book_id
             limit: 5

--- a/src/content/docs/api/guides/GettingAllBooksInLibrary.mdx
+++ b/src/content/docs/api/guides/GettingAllBooksInLibrary.mdx
@@ -1,28 +1,28 @@
 ---
-title: Getting All Books in Your Library
+title: Getting Books in Your Library
 category: guide
-lastUpdated: 2024-10-07
+lastUpdated: 2025-08-13
 layout: /src/layouts/documentation.astro
 ---
 import GraphQLExplorer from '@/components/GraphQLExplorer/GraphQLExplorer.astro';
 
 ## Introduction
 
-This guide will show you how to get all the books in your library using the Hardcover API.
+This guide will show you how to get a list of the books in your library using the Hardcover API. Books are considered "in your library" when they have been marked "Want to Read", "Currently Reading", etc.
 
 ## Related Schemas
 
 - [Books](../../api/graphql/schemas/books)
 
-## Get a list of books belonging to the current user
+## Get a List of Books in a User’s Library
+
+To see a selection of the books in your library, replace `##USER_ID##` with your account id, which can be found by completing the "Example Request" section of the [Getting Started](../../api/getting-started) guide.
 
 <GraphQLExplorer query={`
 {
-      list_books(
+      user_books(
             where: {
-                user_books: {
-                    user_id: {_eq: ##USER_ID##}
-                }
+                user_id: {_eq: ##USER_ID##}
             },
             distinct_on: book_id
             limit: 5


### PR DESCRIPTION
# Description
Updated the query used in the GettingAllBooksInLibrary guide and Book schema pages, based on a comment from Adam Fortuna in Discord mentioning that 'list_books" is intended to be used for retrieving books from a specific list. Discord thread: https://discord.com/channels/835558721115389962/1385756578891960512/1385782418056806562

Additionally, I renamed the display name for "Getting All Books in Your Library"  to "Getting Books in Your Library" to shorten the page name to fit in one line (previously was 2) and better reflect that only a subset of books are returned by the query. I refrained from changing the filename as I did not want to break existing links users may have.

Lastly, I did a quick pass at adding some support text to the "Getting Books in Your Library" page to help ease users in, given this is the first page people see after Getting Started.

The changes here are minimal, but intentionally so as this if my first contribution to the project, so I want to ensure I understand expectations before working on and submitting more extensive changes.

# Hardcover or Discord Username
Hardcover: https://hardcover.app/@aripatrick
Discord:  MrChocolateBear

# Types of changes
- [ ] New content
- [x] Updated content
- [ ] Deleted content
- [ ] Broken link
- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.

# How to test it?
N/A - A minor text and query update.
