### PR TITLE
Update broken links to the standards

### DIFF
--- a/src/content/docs/librarians/Getting-Started.mdx
+++ b/src/content/docs/librarians/Getting-Started.mdx
@@ -35,9 +35,9 @@ The community of librarians is collaborative and supportive. The <a href={URLS.L
 
 ## Access & privileges
 
-As a librarian, you can edit most [book](./standards/bookstandards/), [edition](./standards/editionstandards/), [series](./standards/seriesstandards/) and [author](./standards/authorstandards/) fields in the database. We plan to expand librarian abilities to other data types as well (characters, publishers, etc.)
+As a librarian, you can edit most [book](../standards/bookstandards/), [edition](../standards/editionstandards/), [series](../standards/seriesstandards/) and [author](../standards/authorstandards/) fields in the database. We plan to expand librarian abilities to other data types as well (characters, publishers, etc.)
 
-Other tools available include options to flag duplicates (for [merging](./standards/mergingstandards/)) or split incorrectly merged editions. High-impact actions (like merging popular books or deleting entries) may require additional approval from a Senior Librarian on the Hardcover team.
+Other tools available include options to flag duplicates (for [merging](../standards/mergingstandards/)) or split incorrectly merged editions. High-impact actions (like merging popular books or deleting entries) may require additional approval from a Senior Librarian on the Hardcover team.
 
 ## Combining Supporter roles
 


### PR DESCRIPTION
# Description
The links on [Librarians Getting Started](https://docs.hardcover.app/librarians/getting-started/#access--privileges) Access & privileges are broken.

They go to "https://docs.hardcover.app/librarians/getting-started/standards/editionstandards/" and should go to "https://docs.hardcover.app/librarians/standards/editionstandards/"

# Hardcover or Discord Username
Hardcover [@Honje](https://hardcover.app/@Honje)
Discord Honje

# Types of changes
- [ ] New content
- [ ] Updated content
- [ ] Deleted content
- [x] Broken link
- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [ ] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.
