### PR TITLE
Add hardcover-rs to Showcase

### DIFF
--- a/src/content/showcase/hardcover-rs.yaml
+++ b/src/content/showcase/hardcover-rs.yaml
@@ -1,0 +1,33 @@
+name: "hardcover-rs"
+slug: "hardcover-rs"
+summary: "A strongly typed Rust client library for the Hardcover GraphQL API."
+description: |
+  hardcover-rs is a strongly typed Rust client library for the Hardcover GraphQL API. It is currently in alpha, with no error handling and direct field access for data. Do not use in production!
+  
+  Features:
+  - Natural Interface: Abstracts away querying, authentication, and response parsing.
+  - Typed Data Models: Rich Rust structs and enums matching Hardcover's schema (Books, Editions, Authors, Users, etc).
+  - Asynchronous API: Built with Tokio and Reqwest for async network requests.
+
+author:
+  name: "socalledtheraven"
+  github: "socalledtheraven"
+
+links:
+  - label: "GitHub"
+    url: "https://github.com/socalledtheraven/hardcover-rs"
+    type: "github"
+
+categories:
+  - "Integration"
+
+tags:
+  - "rust"
+  - "wrapper"
+  - "sdk"
+  - "graphql"
+
+dateAdded: 2026-09-11
+dateUpdated: 2026-09-11
+
+featured: false


### PR DESCRIPTION
# Description
I have added my API wrapper, hardcover-rs, to the Showcase. It provides an easy way to access Hardcover data via Rust.

# Hardcover or Discord Username
Hardcover: prophecyreviews
Discord: quintbrit

# Types of changes
- [x] New content
- [ ] Updated content
- [ ] Deleted content
- [ ] Broken link
- [ ] Bug fix
- [ ] New feature
- [ ] Other

# Checklist:
- [x] I have read the [CONTRIBUTING](https://github.com/hardcoverapp/hardcover-docs/blob/main/CONTRIBUTING.md) document.
- [x] I have explained why the change is necessary and how it fits into the existing content.
- [x] I have communicated this change in the [#API](https://discord.com/channels/835558721115389962/1278040045324075050) or [#librarians](https://discord.com/channels/835558721115389962/1105918193022812282) discord channels.